### PR TITLE
Motbank: Identify jmap offset in v3 files and support v4

### DIFF
--- a/REE-Lib/RszFile/MotbankFile.cs
+++ b/REE-Lib/RszFile/MotbankFile.cs
@@ -20,7 +20,7 @@ namespace ReeLib.Motbank
         protected override bool DoRead(FileHandler handler)
         {
             handler.Read(ref offset);
-            if (Version == 3)
+            if (Version >= 3)
             {
                 BankID = handler.ReadInt();
                 handler.Read(ref BankType);
@@ -37,7 +37,7 @@ namespace ReeLib.Motbank
         protected override bool DoWrite(FileHandler handler)
         {
             handler.WriteOffsetWString(Path);
-            if (Version == 3)
+            if (Version >= 3)
             {
                 handler.WriteInt((int)BankID);
                 handler.Write(ref BankType);
@@ -86,14 +86,14 @@ namespace ReeLib
             handler.Skip(8);
             handler.Read(ref motlistsOffset);
             handler.Read(ref uvarOffset);
-            if (version == 3)
+            if (version >= 3)
             {
                 handler.Read(ref jmapOffset);
             }
             handler.Read(ref motlistCount);
 
             UvarPath = handler.ReadWString(uvarOffset);
-            if (version == 3)
+            if (version >= 3)
             {
                 JmapPath = handler.ReadWString(jmapOffset);
             }
@@ -122,7 +122,7 @@ namespace ReeLib
             long motlistsOffsetStart = handler.Tell();
             handler.Write(ref motlistsOffset);
             handler.WriteOffsetWString(UvarPath);
-            if (version == 3)
+            if (version >= 3)
             {
                 handler.WriteOffsetWString(JmapPath);
             }

--- a/REE-Lib/RszFile/MotbankFile.cs
+++ b/REE-Lib/RszFile/MotbankFile.cs
@@ -64,10 +64,11 @@ namespace ReeLib
         // Skip(8);
         public long motlistsOffset;
         public long uvarOffset;
-        public long ukn;
+        public long jmapOffset;
         public int motlistCount;
 
         public string UvarPath { get; set; } = string.Empty;
+        public string JmapPath { get; set; } = string.Empty;
         public List<MotlistItem> MotlistItems { get; } = new();
 
         public const uint Magic = 0x6B6E626D;
@@ -87,11 +88,15 @@ namespace ReeLib
             handler.Read(ref uvarOffset);
             if (version == 3)
             {
-                handler.Read(ref ukn);
+                handler.Read(ref jmapOffset);
             }
             handler.Read(ref motlistCount);
 
             UvarPath = handler.ReadWString(uvarOffset);
+            if (version == 3)
+            {
+                JmapPath = handler.ReadWString(jmapOffset);
+            }
             handler.Seek(motlistsOffset);
             for (int i = 0; i < motlistCount; i++)
             {
@@ -119,7 +124,7 @@ namespace ReeLib
             handler.WriteOffsetWString(UvarPath);
             if (version == 3)
             {
-                handler.Write(ref ukn);
+                handler.WriteOffsetWString(JmapPath);
             }
             handler.Write(ref motlistCount);
             handler.StringTableFlush();


### PR DESCRIPTION
The unknown offset corresponds to jmap string offset.

Sample file from RE4: 

[chc000_10_00__lipsync_vowel.motbank.zip](https://github.com/user-attachments/files/22069857/chc000_10_00__lipsync_vowel.motbank.zip)
